### PR TITLE
Add utility to print working directory

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,9 @@ let package = Package(
     ),
     .testTarget(
       name: "ToolboxTests",
-      dependencies: ["CliKit"],
+      dependencies: [
+        "CliKit",
+      ]
     ),
   ],
 )

--- a/Sources/CliKit/Core/RShell+PrintWorkingDirectory.swift
+++ b/Sources/CliKit/Core/RShell+PrintWorkingDirectory.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension RShell {
+  /// Returns the current working directory as reported by the shell.
+  public func printWorkingDirectory() throws -> String {
+    switch input(command: "pwd") {
+    case .success(let output):
+      return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    case .failure(let error):
+      throw error
+    }
+  }
+}

--- a/Sources/CliKit/Subcommands/PrintWorkingDirectory.swift
+++ b/Sources/CliKit/Subcommands/PrintWorkingDirectory.swift
@@ -17,9 +17,7 @@ struct PWD: ParsableCommand, ConfiguredShell {
   @OptionGroup var options: CliKit.Options
 
   func run() throws {
-    //    let directory = try configuredShell().printWorkingDirectory()
-    #if os(Linux)
-      print(directory)
-    #endif  // os(Linux)
+    let directory = try configuredShell().printWorkingDirectory()
+    print(directory)
   }
 }

--- a/Tests/CliKitTests/CliKitests.swift
+++ b/Tests/CliKitTests/CliKitests.swift
@@ -1,14 +1,11 @@
-import ArgumentParser
-import XCTest
+import Testing
 
 @testable import CliKit
 
-final class ToolboxTests: XCTestCase {
-  func testOptions() {
-    XCTAssertNotNil("Test")
+@Suite struct ToolboxTests {
+  @Test func printWorkingDirectory() throws {
+    let shell = RShell()
+    let directory = try shell.printWorkingDirectory()
+    #expect(!directory.isEmpty)
   }
-
-  static var allTests = [
-    ("testOptions", testOptions)
-  ]
 }


### PR DESCRIPTION
## Summary
- add `RShell.printWorkingDirectory()` helper
- use new helper to implement `pwd` subcommand
- test working directory retrieval using Swift Testing framework
- drop explicit `swift-testing` package dependency and plugin

## Testing
- `codespell -q 3` *(fails: command not found)*
- `codespell --check-filenames` *(fails: command not found)*
- `swift test` *(fails: the package at '/workspace/CommonCommands' cannot be accessed)*

------
https://chatgpt.com/codex/tasks/task_e_689e3b3811d88333980edd79c1e10fa5